### PR TITLE
Add a trailing slash to the script name if it is a directory

### DIFF
--- a/scanners/nmap/scanner.py
+++ b/scanners/nmap/scanner.py
@@ -35,7 +35,7 @@ class Scanner(ScannerInterface):
             script_args = '--script-args %s' % self.script_args if self.script_args else ''
             no_ping = '-Pn' if int(self.pingless) else ''
             ports = '-p %s' % self.ports if self.ports else ''
-            command = 'nmap --script %s %s -sV %s -oX %s %s %s' % (self.script, script_args, no_ping, os.path.abspath(self.filename), ports, self.target_specification)
+            command = 'nmap --script %s %s -sV %s -oX %s %s %s' % (self.format_script(self.script), script_args, no_ping, os.path.abspath(self.filename), ports, self.target_specification)
             process = await asyncio.create_subprocess_exec(*command.split(' '), stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE, cwd=self.script_folder)
             stdout, stderr = await process.communicate()
             self.status = 'done'
@@ -48,6 +48,9 @@ class Scanner(ScannerInterface):
 
     def list_available_scripts(self):
         return [os.path.basename(p) for p in glob.iglob('%s/*' % self.script_folder)]
+
+    def format_script(self, path):
+        return os.path.join(path, '') if os.path.isdir(os.path.join(self.script_folder, path)) else path
 
     def check_dependencies(self, dependencies):
         return dependencies.get('nmap', False)


### PR DESCRIPTION
This is to comply with a change in nmap v7.9.0 to enforce a trailing slash for directories in script names

https://seclists.org/nmap-announce/2020/1
```
[GH#2051] Restrict Nmap's search path for scripts and data files.
NMAPDATADIR, defined on Unix and Linux as ${prefix}/share/nmap, will not be
searched on Windows, where it was previously defined as C:\Nmap .
Additionally, the --script option will not interpret names as directory
names unless they are followed by a '/'. [Daniel Miller]
```