### PR TITLE
Pathfinder `Host` object extension.

### DIFF
--- a/app/objects/secondclass/c_host.py
+++ b/app/objects/secondclass/c_host.py
@@ -22,7 +22,7 @@ class HostSchema(ma.Schema):
     software = ma.fields.List(ma.fields.Nested(ServiceSchema()))
     os = ma.fields.Nested(OSSchema())
     mac = ma.fields.String()
-    freebie_abilities = ma.fields.Dict(keys=ma.fields.String(), values=ma.fields.List())
+    freebie_abilities = ma.fields.List(ma.fields.String())
     denied_abilities = ma.fields.List(ma.fields.String())
     access = ma.fields.Integer()
     access_prob = ma.fields.Dict(keys=ma.fields.String(), values=ma.fields.Float())
@@ -46,7 +46,7 @@ class Host(BaseObject):
         self.software = software or []
         self.os = os
         self.mac = mac
-        self.freebie_abilities = freebie_abilities or dict()
+        self.freebie_abilities = freebie_abilities or []
         self.denied_abilities = denied_abilities or []
         self.access = access or HostAccess.STANDARD
         self.access_prob = access_prob or dict()

--- a/app/objects/secondclass/c_host.py
+++ b/app/objects/secondclass/c_host.py
@@ -1,9 +1,17 @@
+from enum import Enum
 import marshmallow as ma
 
 from app.utility.base_object import BaseObject
 from plugins.pathfinder.app.objects.secondclass.c_port import PortSchema
 from plugins.pathfinder.app.objects.secondclass.c_os import OSSchema
 from plugins.pathfinder.app.objects.secondclass.c_service import ServiceSchema
+
+
+class HostAccess(Enum):
+    deny = -1
+    standard = 0
+    allow = 1
+
 
 class HostSchema(ma.Schema):
 
@@ -14,6 +22,10 @@ class HostSchema(ma.Schema):
     software = ma.fields.List(ma.fields.Nested(ServiceSchema()))
     os = ma.fields.Nested(OSSchema())
     mac = ma.fields.String()
+    freebie_abilities = ma.fields.List(ma.fields.String())
+    denied_abilities = ma.fields.List(ma.fields.String())
+    access = ma.fields.Integer()
+    access_prob = ma.fields.Dict(keys=ma.fields.String(), values=ma.fields.Float())
 
     @ma.post_load()
     def build_host(self, data, **_):
@@ -24,7 +36,8 @@ class Host(BaseObject):
 
     schema = HostSchema()
 
-    def __init__(self, ip, hostname=None, ports=None, cves=None, software=None, os=None, mac=None, match='.*'):
+    def __init__(self, ip, hostname=None, ports=None, cves=None, software=None, os=None, mac=None,
+                 freebie_abilities=None, denied_abilities=None, access=None, access_prob=None, match='.*'):
         super().__init__()
         self.hostname = hostname
         self.ip = ip
@@ -33,3 +46,7 @@ class Host(BaseObject):
         self.software = software or []
         self.os = os
         self.mac = mac
+        self.freebie_abilities = freebie_abilities or []
+        self.denied_abilities = denied_abilities or []
+        self.access = access or 0
+        self.access_prob = access_prob or dict()

--- a/app/objects/secondclass/c_host.py
+++ b/app/objects/secondclass/c_host.py
@@ -23,9 +23,10 @@ class HostSchema(ma.Schema):
     os = ma.fields.Nested(OSSchema())
     mac = ma.fields.String()
     freebie_abilities = ma.fields.List(ma.fields.String())
+    possible_abilities = ma.fields.List(ma.fields.String())
     denied_abilities = ma.fields.List(ma.fields.String())
     access = ma.fields.Integer()
-    access_prob = ma.fields.Dict(keys=ma.fields.String(), values=ma.fields.Float())
+    access_prob = ma.fields.Number()
 
     @ma.post_load()
     def build_host(self, data, **_):
@@ -37,7 +38,8 @@ class Host(BaseObject):
     schema = HostSchema()
 
     def __init__(self, ip, hostname=None, ports=None, cves=None, software=None, os=None, mac=None,
-                 freebie_abilities=None, denied_abilities=None, access=None, access_prob=None, match='.*'):
+                 freebie_abilities=None, possible_abilities=None, denied_abilities=None, access=None, access_prob=None,
+                 match='.*'):
         super().__init__()
         self.hostname = hostname
         self.ip = ip
@@ -47,6 +49,7 @@ class Host(BaseObject):
         self.os = os
         self.mac = mac
         self.freebie_abilities = freebie_abilities or []
+        self.possible_abilities = possible_abilities or []
         self.denied_abilities = denied_abilities or []
         self.access = access or HostAccess.STANDARD
-        self.access_prob = access_prob or dict()
+        self.access_prob = access_prob or 1.0

--- a/app/objects/secondclass/c_host.py
+++ b/app/objects/secondclass/c_host.py
@@ -13,6 +13,11 @@ class HostAccess(Enum):
     ALLOW = 1
 
 
+class AbilitySchema(ma.Schema):
+    uuid = ma.fields.String()
+    success_prob = ma.fields.Number()
+
+
 class HostSchema(ma.Schema):
 
     hostname = ma.fields.String()
@@ -23,7 +28,7 @@ class HostSchema(ma.Schema):
     os = ma.fields.Nested(OSSchema())
     mac = ma.fields.String()
     freebie_abilities = ma.fields.List(ma.fields.String())
-    possible_abilities = ma.fields.List(ma.fields.String())
+    possible_abilities = ma.fields.Nested(AbilitySchema())
     denied_abilities = ma.fields.List(ma.fields.String())
     access = ma.fields.Integer()
     access_prob = ma.fields.Number()

--- a/app/objects/secondclass/c_host.py
+++ b/app/objects/secondclass/c_host.py
@@ -46,7 +46,7 @@ class Host(BaseObject):
         self.software = software or []
         self.os = os
         self.mac = mac
-        self.freebie_abilities = freebie_abilities or []
+        self.freebie_abilities = freebie_abilities or dict()
         self.denied_abilities = denied_abilities or []
         self.access = access or HostAccess.STANDARD
         self.access_prob = access_prob or dict()

--- a/app/objects/secondclass/c_host.py
+++ b/app/objects/secondclass/c_host.py
@@ -22,7 +22,7 @@ class HostSchema(ma.Schema):
     software = ma.fields.List(ma.fields.Nested(ServiceSchema()))
     os = ma.fields.Nested(OSSchema())
     mac = ma.fields.String()
-    freebie_abilities = ma.fields.List(ma.fields.String())
+    freebie_abilities = ma.fields.Dict(keys=ma.fields.String(), values=ma.fields.List())
     denied_abilities = ma.fields.List(ma.fields.String())
     access = ma.fields.Integer()
     access_prob = ma.fields.Dict(keys=ma.fields.String(), values=ma.fields.Float())

--- a/app/objects/secondclass/c_host.py
+++ b/app/objects/secondclass/c_host.py
@@ -8,9 +8,9 @@ from plugins.pathfinder.app.objects.secondclass.c_service import ServiceSchema
 
 
 class HostAccess(Enum):
-    deny = -1
-    standard = 0
-    allow = 1
+    DENY = -1
+    STANDARD = 0
+    ALLOW = 1
 
 
 class HostSchema(ma.Schema):
@@ -48,5 +48,5 @@ class Host(BaseObject):
         self.mac = mac
         self.freebie_abilities = freebie_abilities or []
         self.denied_abilities = denied_abilities or []
-        self.access = access or 0
+        self.access = access or HostAccess.STANDARD
         self.access_prob = access_prob or dict()


### PR DESCRIPTION
Pathfinder host object extension.

New concepts for host/ability pairs including:
* freebie ability for a given host,
* freebie node (host which already has an implant deployed),
* `DENIED` ability for a given host,
* `DENIED` node (host which cannot be accessed),
* Ability success probabilities for each host