### PR TITLE
XML Parser fix [Resolves Issue #45]

### DIFF
--- a/app/parsers/nmap.py
+++ b/app/parsers/nmap.py
@@ -77,7 +77,7 @@ class ReportParser(ParserInterface):
         for host_object in report.hosts.values():
             network_map.add_node(host_object.ip)
             for host2 in report.hosts.values():
-                if host2 != value:
+                if host2 != host_object:
                     network_map.add_edge(host_object.ip, host2.ip)
         report.network_map = network_map
 

--- a/app/parsers/siesta.py
+++ b/app/parsers/siesta.py
@@ -14,11 +14,11 @@ class ReportParser(ParserInterface):
         self.format = 'siesta'
         self.log = logging.getLogger('siesta parser')
 
-    def parse(self, report):
+    def parse(self, report, name=None):
         try:
             with open(report, 'r') as f:
                 siesta_report = json.load(f)
-            caldera_report = self.parse_json_report(siesta_report)
+            caldera_report = self.parse_json_report(siesta_report, name)
             self.generate_network_map(caldera_report)
         except Exception as e:
             self.log.error('exception when parsing siesta report: %s' % repr(e))
@@ -26,8 +26,8 @@ class ReportParser(ParserInterface):
 
         return caldera_report
 
-    def parse_json_report(self, siesta_report):
-        report = VulnerabilityReport()
+    def parse_json_report(self, siesta_report, name):
+        report = VulnerabilityReport(name=name)
         hosts = siesta_report['facts']['components']
         all_ports = siesta_report['facts']['ports']
         all_vulnerabilities = siesta_report['facts']['vulnerabilities']

--- a/app/pathfinder_svc.py
+++ b/app/pathfinder_svc.py
@@ -31,7 +31,7 @@ class PathfinderService:
             temp_file = '%s/_temp_report_file.tmp' % settings.data_dir
             with open(temp_file, 'wb') as f:
                 f.write(contents)
-            parsed_report = self.parsers[scan_format].parse(temp_file)
+            parsed_report = self.parsers[scan_format].parse(temp_file, name=report)
             parsed_report = self.enrich_report(parsed_report)
             if parsed_report:
                 await self.data_svc.store(parsed_report)


### PR DESCRIPTION
This PR contains two minor changes affecting report parsing and in-UI display.

# NMAP scans (either executed in the `Scan` Tab or imported as `.xml` files) are now successfully imported.
* `app/parsers/nmap.py` `generate_network_map` line 80 changed `value` to `host_object`.
* Verified successful parsing for nmap and nmap-vulners scans in UI, as well as existing nmap scans (with out without the `.xml` extension)
# Report names are correctly filled from the filed in the `Scan` tab, or from the filename of a report loaded through the `Import` tab.
* Verified correct behavior using nmap scans (both in-UI and existing), as well as CALDERA report files (where the name is read from the name field, rather than the filename).